### PR TITLE
Optional callback phase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ t/servroot*
 lua-resty-mlcache-*/
 *.tar.gz
 *.rock
+*.idea

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,3 +1,3 @@
 std             = "ngx_lua"
 redefined       = false
-max_line_length = 80
+max_line_length = 90

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,3 +1,3 @@
 std             = "ngx_lua"
 redefined       = false
-max_line_length = 90
+max_line_length = 80

--- a/lib/resty/mlcache.lua
+++ b/lib/resty/mlcache.lua
@@ -975,8 +975,10 @@ function _M:get_bulk(bulk, opts)
             if opts.concurrency <= 0 then
                 error("opts.concurrency must be > 0", 2)
             end
+        end
+
         if opts.skip_callback and type(opts.skip_callback) ~= "boolean" then
-                error("opts.skip_callback must be a boolean", 2)
+            error("opts.skip_callback must be a boolean", 2)
         end
     end
 

--- a/lib/resty/mlcache.lua
+++ b/lib/resty/mlcache.lua
@@ -1028,7 +1028,8 @@ function _M:get_bulk(bulk, opts)
             local pok, ttl, neg_ttl, resurrect_ttl, l1_serializer,
             shm_set_tries, skip_callback = pcall(check_opts, self, b_opts)
 
-            -- override skip_callback from bulk item level with the one set up al bulk level
+            -- override skip_callback from bulk item level
+            -- with the one set up al bulk level
             if opts and opts.skip_callback then
                 skip_callback = opts.skip_callback
             end

--- a/lib/resty/mlcache.lua
+++ b/lib/resty/mlcache.lua
@@ -186,7 +186,8 @@ function _M.new(name, shm, opts)
             error("opts must be a table", 2)
         end
 
-        if opts.skip_callback ~= nil and type(opts.skip_callback) ~= "boolean" then
+        if opts.skip_callback ~= nil and
+                type(opts.skip_callback) ~= "boolean" then
             error("opts.skip_callback must be a boolean", 2)
         end
 
@@ -672,11 +673,12 @@ local function check_opts(self, opts)
         shm_set_tries = self.shm_set_tries
     end
 
-    if not skip_callback then
+    if skip_callback == nil then
         skip_callback = self.skip_callback
     end
 
-    return ttl, neg_ttl, resurrect_ttl, l1_serializer, shm_set_tries, skip_callback
+    return ttl, neg_ttl, resurrect_ttl, l1_serializer,
+    shm_set_tries, skip_callback
 end
 
 
@@ -837,8 +839,8 @@ function _M:get(key, opts, cb, ...)
     end
 
     -- opts validation
-    local ttl, neg_ttl, resurrect_ttl, l1_serializer, shm_set_tries, skip_callback
-        = check_opts(self, opts)
+    local ttl, neg_ttl, resurrect_ttl, l1_serializer,
+    shm_set_tries, skip_callback = check_opts(self, opts)
 
     if skip_callback ~= true and type(cb) ~= "function" then
         error("callback must be a function", 2)
@@ -977,7 +979,8 @@ function _M:get_bulk(bulk, opts)
             end
         end
 
-        if opts.skip_callback and type(opts.skip_callback) ~= "boolean" then
+        if opts.skip_callback ~= nil
+                and type(opts.skip_callback) ~= "boolean" then
             error("opts.skip_callback must be a boolean", 2)
         end
     end
@@ -1030,7 +1033,7 @@ function _M:get_bulk(bulk, opts)
 
             -- override skip_callback from bulk item level
             -- with the one set up al bulk level
-            if opts and opts.skip_callback then
+            if opts and opts.skip_callback ~= nil then
                 skip_callback = opts.skip_callback
             end
 

--- a/lib/resty/mlcache.lua
+++ b/lib/resty/mlcache.lua
@@ -1027,6 +1027,12 @@ function _M:get_bulk(bulk, opts)
         else
             local pok, ttl, neg_ttl, resurrect_ttl, l1_serializer,
             shm_set_tries, skip_callback = pcall(check_opts, self, b_opts)
+
+            -- override skip_callback from bulk item level with the one set up al bulk level
+            if opts and opts.skip_callback then
+                skip_callback = opts.skip_callback
+            end
+
             if not pok then
                 -- strip the stacktrace
                 local err = ttl:match("mlcache%.lua:%d+:%s(.*)")
@@ -1056,7 +1062,7 @@ function _M:get_bulk(bulk, opts)
                 --res[res_idx + 1] = nil
                 res[res_idx + 2] = is_stale and 4 or 2
 
-            elseif opts.skip_callback ~= true and skip_callback ~= true then
+            elseif skip_callback ~= true then
                 -- not in shm either, we have to prepare a task to run the
                 -- L3 callback
 

--- a/lib/resty/mlcache.lua
+++ b/lib/resty/mlcache.lua
@@ -1278,8 +1278,8 @@ function _M:set(key, opts, value)
         -- restrict this key to the current namespace, so we isolate this
         -- mlcache instance from potential other instances using the same
         -- shm
-        local ttl, neg_ttl, _, l1_serializer, shm_set_tries, _ = check_opts(self,
-                                                                         opts)
+        local ttl, neg_ttl, _, l1_serializer, shm_set_tries, _ =
+        check_opts(self, opts)
         local namespaced_key = self.name .. key
 
         if self.dict_miss then

--- a/lib/resty/mlcache.lua
+++ b/lib/resty/mlcache.lua
@@ -187,7 +187,8 @@ function _M.new(name, shm, opts)
         end
 
         if opts.skip_callback ~= nil and
-                type(opts.skip_callback) ~= "boolean" then
+            type(opts.skip_callback) ~= "boolean"
+        then
             error("opts.skip_callback must be a boolean", 2)
         end
 
@@ -678,7 +679,7 @@ local function check_opts(self, opts)
     end
 
     return ttl, neg_ttl, resurrect_ttl, l1_serializer,
-    shm_set_tries, skip_callback
+        shm_set_tries, skip_callback
 end
 
 
@@ -840,7 +841,7 @@ function _M:get(key, opts, cb, ...)
 
     -- opts validation
     local ttl, neg_ttl, resurrect_ttl, l1_serializer,
-    shm_set_tries, skip_callback = check_opts(self, opts)
+        shm_set_tries, skip_callback = check_opts(self, opts)
 
     if skip_callback ~= true and type(cb) ~= "function" then
         error("callback must be a function", 2)
@@ -980,7 +981,8 @@ function _M:get_bulk(bulk, opts)
         end
 
         if opts.skip_callback ~= nil
-                and type(opts.skip_callback) ~= "boolean" then
+                and type(opts.skip_callback) ~= "boolean"
+        then
             error("opts.skip_callback must be a boolean", 2)
         end
     end
@@ -1009,12 +1011,6 @@ function _M:get_bulk(bulk, opts)
                   ceil(i / 4) .. " (got " .. type(b_key) .. ")", 2)
         end
 
-        if b_cb ~= nil and type(b_cb) ~= "function" then
-            error("callback at index " .. i + 2 .. " must be a function " ..
-                  "for operation " .. ceil(i / 4) .. " (got " .. type(b_cb) ..
-                  ")", 2)
-        end
-
         -- worker LRU cache retrieval
 
         local data = self.lru:get(b_key)
@@ -1029,12 +1025,18 @@ function _M:get_bulk(bulk, opts)
 
         else
             local pok, ttl, neg_ttl, resurrect_ttl, l1_serializer,
-            shm_set_tries, skip_callback = pcall(check_opts, self, b_opts)
+                shm_set_tries, skip_callback = pcall(check_opts, self, b_opts)
 
-            -- override skip_callback from bulk item level
-            -- with the one set up al bulk level
+            -- override skip_callback from entry level
+            -- with the one set up at bulk level
             if opts and opts.skip_callback ~= nil then
                 skip_callback = opts.skip_callback
+            end
+
+            if skip_callback ~= true and type(b_cb) ~= "function" then
+                error("callback at index " .. i + 2 .. " must be a function " ..
+                        "for operation " .. ceil(i / 4) .. " (got " ..
+                        type(b_cb) .. ")", 2)
             end
 
             if not pok then
@@ -1279,7 +1281,7 @@ function _M:set(key, opts, value)
         -- mlcache instance from potential other instances using the same
         -- shm
         local ttl, neg_ttl, _, l1_serializer, shm_set_tries, _ =
-        check_opts(self, opts)
+            check_opts(self, opts)
         local namespaced_key = self.name .. key
 
         if self.dict_miss then

--- a/lib/resty/mlcache.lua
+++ b/lib/resty/mlcache.lua
@@ -1025,8 +1025,8 @@ function _M:get_bulk(bulk, opts)
             res[res_idx + 2] = 1
 
         else
-            local pok, ttl, neg_ttl, resurrect_ttl, l1_serializer, shm_set_tries, skip_callback
-                = pcall(check_opts, self, b_opts)
+            local pok, ttl, neg_ttl, resurrect_ttl, l1_serializer,
+            shm_set_tries, skip_callback = pcall(check_opts, self, b_opts)
             if not pok then
                 -- strip the stacktrace
                 local err = ttl:match("mlcache%.lua:%d+:%s(.*)")

--- a/t/02-get.t
+++ b/t/02-get.t
@@ -129,7 +129,7 @@ opts must be a table
 
 
 
-=== TEST 41: get() does not call callback when skip_callback option is set to true in new()
+=== TEST 411: get() does not call callback when skip_callback option is set to true in new()
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -163,14 +163,14 @@ from shm: nil nil
 
 
 
-=== TEST 42: get() does not call callback when skip_callback option is set to true in get()
+=== TEST 412: get() does not call callback when skip_callback option is set to true in get()
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
         content_by_lua_block {
             local mlcache = require "resty.mlcache"
 
-            local cache, err = mlcache.new("my_mlcache", "cache_shm", { skip_callback = true })
+            local cache, err = mlcache.new("my_mlcache", "cache_shm", { skip_callback = false })
             if not cache then
                 ngx.log(ngx.ERR, err)
                 return
@@ -197,7 +197,7 @@ from shm: nil nil
 
 
 
-=== TEST 43: get() calls callback when skip_callback option is explicitly set to false in new()
+=== TEST 413: get() calls callback when skip_callback option is explicitly set to false in new()
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {

--- a/t/02-get.t
+++ b/t/02-get.t
@@ -129,7 +129,7 @@ opts must be a table
 
 
 
-=== TEST 411: get() does not call callback when skip_callback option is set to true in new()
+=== TEST 4: get() does not call callback when skip_callback option is set to true in new()
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -163,7 +163,7 @@ result: nil nil
 
 
 
-=== TEST 412: get() does not call callback when skip_callback option is set to true in get()
+=== TEST 5: get() does not call callback when skip_callback option is set to true in get()
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -197,7 +197,7 @@ result: nil nil
 
 
 
-=== TEST 413: get() calls callback when skip_callback option is explicitly set to false in get()
+=== TEST 6: get() calls callback when skip_callback option is explicitly set to false in get()
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -231,7 +231,7 @@ result: number 123
 
 
 
-=== TEST 4: get() calls callback in protected mode with stack traceback
+=== TEST 7: get() calls callback in protected mode with stack traceback
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -266,7 +266,7 @@ stack traceback:
 
 
 
-=== TEST 5: get() is resilient to callback runtime errors with non-string arguments
+=== TEST 8: get() is resilient to callback runtime errors with non-string arguments
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -300,7 +300,7 @@ callback threw an error: table: 0x[0-9a-fA-F]+
 
 
 
-=== TEST 6: get() caches a number
+=== TEST 9: get() caches a number
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -361,7 +361,7 @@ from shm: number 123
 
 
 
-=== TEST 7: get() caches a boolean (true)
+=== TEST 10: get() caches a boolean (true)
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -422,7 +422,7 @@ from shm: boolean true
 
 
 
-=== TEST 8: get() caches a boolean (false)
+=== TEST 11: get() caches a boolean (false)
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -483,7 +483,7 @@ from shm: boolean false
 
 
 
-=== TEST 9: get() caches nil
+=== TEST 12: get() caches nil
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -544,7 +544,7 @@ from shm: nil nil
 
 
 
-=== TEST 10: get() caches nil in 'shm_miss' if specified
+=== TEST 13: get() caches nil in 'shm_miss' if specified
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -625,7 +625,7 @@ value in lru is a sentinel nil value: true
 
 
 
-=== TEST 11: get() caches a string
+=== TEST 14: get() caches a string
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -686,7 +686,7 @@ from shm: string hello world
 
 
 
-=== TEST 12: get() caches a table
+=== TEST 15: get() caches a table
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -751,7 +751,7 @@ from shm: table world bar
 
 
 
-=== TEST 13: get() errors when caching an unsupported type
+=== TEST 16: get() errors when caching an unsupported type
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -784,7 +784,7 @@ qr/\[error\] .*?mlcache\.lua:\d+: cannot cache value of type userdata/
 
 
 
-=== TEST 14: get() calls callback with args
+=== TEST 17: get() calls callback with args
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -819,7 +819,7 @@ GET /t
 
 
 
-=== TEST 15: get() caches hit for 'ttl' from LRU (in ms)
+=== TEST 18: get() caches hit for 'ttl' from LRU (in ms)
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -857,7 +857,7 @@ in callback
 
 
 
-=== TEST 16: get() caches miss (nil) for 'neg_ttl' from LRU (in ms)
+=== TEST 19: get() caches miss (nil) for 'neg_ttl' from LRU (in ms)
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -901,7 +901,7 @@ in callback
 
 
 
-=== TEST 17: get() caches for 'opts.ttl' from LRU (in ms)
+=== TEST 20: get() caches for 'opts.ttl' from LRU (in ms)
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -939,7 +939,7 @@ in callback
 
 
 
-=== TEST 18: get() caches for 'opts.neg_ttl' from LRU (in ms)
+=== TEST 21: get() caches for 'opts.neg_ttl' from LRU (in ms)
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -980,7 +980,7 @@ in callback
 
 
 
-=== TEST 19: get() with ttl of 0 means indefinite caching
+=== TEST 22: get() with ttl of 0 means indefinite caching
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -1027,7 +1027,7 @@ in shm after exp: 123
 
 
 
-=== TEST 20: get() with neg_ttl of 0 means indefinite caching for nil values
+=== TEST 23: get() with neg_ttl of 0 means indefinite caching for nil values
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -1076,7 +1076,7 @@ in shm after exp: nil
 
 
 
-=== TEST 21: get() errors when ttl < 0
+=== TEST 24: get() errors when ttl < 0
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -1109,7 +1109,7 @@ opts.ttl must be >= 0
 
 
 
-=== TEST 22: get() errors when neg_ttl < 0
+=== TEST 25: get() errors when neg_ttl < 0
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -1142,7 +1142,7 @@ opts.neg_ttl must be >= 0
 
 
 
-=== TEST 23: get() shm -> LRU caches for 'opts.ttl - since' in ms
+=== TEST 26: get() shm -> LRU caches for 'opts.ttl - since' in ms
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -1200,7 +1200,7 @@ is stale in LRU: 123
 
 
 
-=== TEST 24: get() shm -> LRU caches non-nil for 'indefinite' if ttl is 0
+=== TEST 27: get() shm -> LRU caches non-nil for 'indefinite' if ttl is 0
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -1244,7 +1244,7 @@ is not expired in LRU: 123
 
 
 
-=== TEST 25: get() shm -> LRU caches for 'opts.neg_ttl - since' in ms
+=== TEST 28: get() shm -> LRU caches for 'opts.neg_ttl - since' in ms
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -1304,7 +1304,7 @@ is stale in LRU: table: \S+
 
 
 
-=== TEST 26: get() shm -> LRU caches nil for 'indefinite' if neg_ttl is 0
+=== TEST 29: get() shm -> LRU caches nil for 'indefinite' if neg_ttl is 0
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -1347,7 +1347,7 @@ is stale in LRU: nil
 
 
 
-=== TEST 27: get() returns hit level
+=== TEST 30: get() returns hit level
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -1385,7 +1385,7 @@ hit level from shm: 2
 
 
 
-=== TEST 28: get() returns hit level for nil hits
+=== TEST 31: get() returns hit level for nil hits
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -1423,7 +1423,7 @@ hit level from shm: 2
 
 
 
-=== TEST 29: get() returns hit level for boolean false hits
+=== TEST 32: get() returns hit level for boolean false hits
 --- skip_eval: 3: t::Util::skip_openresty('<', '1.11.2.3')
 --- http_config eval: $::HttpConfig
 --- config
@@ -1462,7 +1462,7 @@ hit level from shm: 2
 
 
 
-=== TEST 30: get() JITs when hit coming from LRU
+=== TEST 33: get() JITs when hit coming from LRU
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -1492,7 +1492,7 @@ qr/\[TRACE\s+\d+ content_by_lua\(nginx\.conf:\d+\):10 loop\]/
 
 
 
-=== TEST 31: get() JITs when hit of scalar value coming from shm
+=== TEST 34: get() JITs when hit of scalar value coming from shm
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -1556,7 +1556,7 @@ GET /t
 
 
 
-=== TEST 32: get() JITs when hit of table value coming from shm
+=== TEST 35: get() JITs when hit of table value coming from shm
 --- SKIP: blocked until custom table serializer
 --- http_config eval: $::HttpConfig
 --- config
@@ -1590,7 +1590,7 @@ qr/\[TRACE\s+\d+ content_by_lua\(nginx\.conf:\d+\):18 loop\]/
 
 
 
-=== TEST 33: get() JITs when miss coming from LRU
+=== TEST 36: get() JITs when miss coming from LRU
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -1621,7 +1621,7 @@ qr/\[TRACE\s+\d+ content_by_lua\(nginx\.conf:\d+\):10 loop\]/
 
 
 
-=== TEST 34: get() JITs when miss coming from shm
+=== TEST 37: get() JITs when miss coming from shm
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -1654,7 +1654,7 @@ qr/\[TRACE\s+\d+ content_by_lua\(nginx\.conf:\d+\):10 loop\]/
 
 
 
-=== TEST 35: get() callback can return nil + err (string)
+=== TEST 38: get() callback can return nil + err (string)
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -1694,7 +1694,7 @@ cb2 return values: foo an error occurred again
 
 
 
-=== TEST 36: get() callback can return nil + err (non-string) safely
+=== TEST 39: get() callback can return nil + err (non-string) safely
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -1733,7 +1733,7 @@ cb2 return values: foo table: 0x[[:xdigit:]]+
 
 
 
-=== TEST 37: get() callback can return nil + err (table) and will call __tostring
+=== TEST 40: get() callback can return nil + err (table) and will call __tostring
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -1766,7 +1766,7 @@ cb return values: nil hello from __tostring
 
 
 
-=== TEST 38: get() callback's 3th return value can override the ttl
+=== TEST 41: get() callback's 3th return value can override the ttl
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -1817,7 +1817,7 @@ in callback 2
 
 
 
-=== TEST 39: get() callback's 3th return value can override the neg_ttl
+=== TEST 42: get() callback's 3th return value can override the neg_ttl
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -1868,7 +1868,7 @@ in callback 2
 
 
 
-=== TEST 40: get() ignores invalid callback 3rd return value (not number)
+=== TEST 43: get() ignores invalid callback 3rd return value (not number)
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -1947,7 +1947,7 @@ in positive callback
 
 
 
-=== TEST 41: get() passes 'resty_lock_opts' for L3 calls
+=== TEST 44: get() passes 'resty_lock_opts' for L3 calls
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -1990,7 +1990,7 @@ was given 'opts.resty_lock_opts': true
 
 
 
-=== TEST 42: get() errors on lock timeout
+=== TEST 45: get() errors on lock timeout
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -2070,7 +2070,7 @@ hit_lvl: 1
 
 
 
-=== TEST 43: get() returns data even if failed to set in shm
+=== TEST 46: get() returns data even if failed to set in shm
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -2122,7 +2122,7 @@ qr/\[warn\] .*? could not write to lua_shared_dict 'cache_shm' after 3 tries \(n
 
 
 
-=== TEST 44: get() errors on invalid opts.shm_set_tries
+=== TEST 47: get() errors on invalid opts.shm_set_tries
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -2162,7 +2162,7 @@ opts.shm_set_tries must be >= 1
 
 
 
-=== TEST 45: get() with default shm_set_tries to LRU evict items when a large value is being cached
+=== TEST 48: get() with default shm_set_tries to LRU evict items when a large value is being cached
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -2233,7 +2233,7 @@ callback was called: 1 times
 
 
 
-=== TEST 46: get() respects instance opts.shm_set_tries to LRU evict items when a large value is being cached
+=== TEST 49: get() respects instance opts.shm_set_tries to LRU evict items when a large value is being cached
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -2306,7 +2306,7 @@ callback was called: 1 times
 
 
 
-=== TEST 47: get() accepts opts.shm_set_tries to LRU evict items when a large value is being cached
+=== TEST 50: get() accepts opts.shm_set_tries to LRU evict items when a large value is being cached
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -2379,7 +2379,7 @@ callback was called: 1 times
 
 
 
-=== TEST 48: get() caches data in L1 LRU even if failed to set in shm
+=== TEST 51: get() caches data in L1 LRU even if failed to set in shm
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -2443,7 +2443,7 @@ is stale: true
 
 
 
-=== TEST 49: get() does not cache value in LRU indefinitely when retrieved from shm on last ms (see GH PR #58)
+=== TEST 52: get() does not cache value in LRU indefinitely when retrieved from shm on last ms (see GH PR #58)
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -2508,7 +2508,7 @@ GET /t
 
 
 
-=== TEST 50: get() bypass cache for negative callback TTL
+=== TEST 53: get() bypass cache for negative callback TTL
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {

--- a/t/02-get.t
+++ b/t/02-get.t
@@ -170,7 +170,7 @@ from shm: nil nil
         content_by_lua_block {
             local mlcache = require "resty.mlcache"
 
-            local cache, err = mlcache.new("my_mlcache", "cache_shm", { skip_callback = false })
+            local cache, err = mlcache.new("my_mlcache", "cache_shm", { skip_callback = true })
             if not cache then
                 ngx.log(ngx.ERR, err)
                 return

--- a/t/02-get.t
+++ b/t/02-get.t
@@ -148,7 +148,7 @@ opts must be a table
 
             local data, err = cache:get("key", nil, cb)
             if err then
-                ngx.say(err)
+                ngx.log(ngx.ERR, err)
             end
         }
     }
@@ -182,7 +182,7 @@ from shm: nil nil
 
             local data, err = cache:get("key", { skip_callback = true }, cb)
             if err then
-                ngx.say(err)
+                ngx.log(ngx.ERR, err)
             end
         }
     }
@@ -216,7 +216,7 @@ from shm: nil nil
 
             local data, err = cache:get("key", nil , cb)
             if err then
-                ngx.say(err)
+                ngx.log(ngx.ERR, err)
             end
         }
     }

--- a/t/02-get.t
+++ b/t/02-get.t
@@ -129,6 +129,108 @@ opts must be a table
 
 
 
+=== TEST 41: get() does not call callback when skip_callback option is set to true in new()
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local mlcache = require "resty.mlcache"
+
+            local cache, err = mlcache.new("my_mlcache", "cache_shm", { skip_callback = true })
+            if not cache then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            local function cb()
+                return 123
+            end
+
+            local data, err = cache:get("key", nil, cb)
+            if err then
+                ngx.say(err)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+from callback: nil nil
+from lru: nil nil
+from shm: nil nil
+--- no_error_log
+[error]
+
+
+
+=== TEST 42: get() does not call callback when skip_callback option is set to true in get()
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local mlcache = require "resty.mlcache"
+
+            local cache, err = mlcache.new("my_mlcache", "cache_shm", { skip_callback = true })
+            if not cache then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            local function cb()
+                return 123
+            end
+
+            local data, err = cache:get("key", { skip_callback = true }, cb)
+            if err then
+                ngx.say(err)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+from callback: nil nil
+from lru: nil nil
+from shm: nil nil
+--- no_error_log
+[error]
+
+
+
+=== TEST 43: get() calls callback when skip_callback option is explicitly set to false in new()
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local mlcache = require "resty.mlcache"
+
+            local cache, err = mlcache.new("my_mlcache", "cache_shm", { skip_callback = false })
+            if not cache then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            local function cb()
+                return 123
+            end
+
+            local data, err = cache:get("key", nil , cb)
+            if err then
+                ngx.say(err)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+from callback: number 123
+from lru: number 123
+from shm: number 123
+--- no_error_log
+[error]
+
+
+
 === TEST 4: get() calls callback in protected mode with stack traceback
 --- http_config eval: $::HttpConfig
 --- config

--- a/t/13-get_bulk.t
+++ b/t/13-get_bulk.t
@@ -286,7 +286,7 @@ GET /t
 
 
 
-=== TEST 71: get_bulk() skip multiple fetch L3 if skip_callback is set to true
+=== TEST 8: get_bulk() skip all fetch L3 if skip_callback is set to true at bulk level
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -324,7 +324,7 @@ nil nil nil
 
 
 
-=== TEST 72: get_bulk() skip a fetch L3 if skip_callback is set to true for one of the bulk items
+=== TEST 9: get_bulk() skip a fetch L3 if skip_callback is set to true for its corresponding bulk entry
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -362,7 +362,7 @@ nil nil nil
 
 
 
-=== TEST 73: get_bulk() ignore skip_callback at bulk item level when specified al bulk level
+=== TEST 10: get_bulk() ignore skip_callback at entry level when set to false at bulk level
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -399,7 +399,7 @@ GET /t
 [error]
 
 
-=== TEST 8: get_bulk() multiple fetch L2
+=== TEST 11: get_bulk() multiple fetch L2
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -444,7 +444,7 @@ GET /t
 
 
 
-=== TEST 9: get_bulk() multiple fetch L1
+=== TEST 12: get_bulk() multiple fetch L1
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -485,7 +485,7 @@ GET /t
 
 
 
-=== TEST 10: get_bulk() multiple fetch L1/single fetch L3
+=== TEST 13: get_bulk() multiple fetch L1/single fetch L3
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -525,7 +525,7 @@ GET /t
 
 
 
-=== TEST 11: get_bulk() multiple fetch L1/single fetch L3 (with nils)
+=== TEST 14: get_bulk() multiple fetch L1/single fetch L3 (with nils)
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -567,7 +567,7 @@ nil nil 3
 
 
 
-=== TEST 12: get_bulk() mixed fetch L1/L2/L3
+=== TEST 15: get_bulk() mixed fetch L1/L2/L3
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -610,7 +610,7 @@ GET /t
 
 
 
-=== TEST 13: get_bulk() mixed fetch L1/L2/L3 (with nils)
+=== TEST 16: get_bulk() mixed fetch L1/L2/L3 (with nils)
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -655,7 +655,7 @@ nil nil 3
 
 
 
-=== TEST 14: get_bulk() returns callback-returned errors
+=== TEST 17: get_bulk() returns callback-returned errors
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -692,7 +692,7 @@ nil some error nil
 
 
 
-=== TEST 15: get_bulk() returns callback runtime errors
+=== TEST 18: get_bulk() returns callback runtime errors
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -731,7 +731,7 @@ stack traceback:
 
 
 
-=== TEST 16: get_bulk() runs L3 callback on expired keys
+=== TEST 19: get_bulk() runs L3 callback on expired keys
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -776,7 +776,7 @@ GET /t
 
 
 
-=== TEST 17: get_bulk() honors ttl and neg_ttl instance attributes
+=== TEST 20: get_bulk() honors ttl and neg_ttl instance attributes
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -823,7 +823,7 @@ key_b: nil (ttl: 0.3)
 
 
 
-=== TEST 18: get_bulk() validates operations ttl and neg_ttl
+=== TEST 21: get_bulk() validates operations ttl and neg_ttl
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -860,7 +860,7 @@ options at index 6 for operation 2 are invalid: opts.neg_ttl must be a number
 
 
 
-=== TEST 19: get_bulk() accepts ttl and neg_ttl for each operation
+=== TEST 22: get_bulk() accepts ttl and neg_ttl for each operation
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -907,7 +907,7 @@ key_b: nil (ttl: 0.8)
 
 
 
-=== TEST 20: get_bulk() honors ttl from callback return values
+=== TEST 23: get_bulk() honors ttl from callback return values
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -953,7 +953,7 @@ key_b: 2 (ttl: 1)
 
 
 
-=== TEST 21: get_bulk() honors resurrect_ttl instance attribute
+=== TEST 24: get_bulk() honors resurrect_ttl instance attribute
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -1015,7 +1015,7 @@ key_b: 3 ttl: 0\.(?:1|0)\d+
 
 
 
-=== TEST 22: get_bulk() accepts resurrect_ttl for each operation
+=== TEST 25: get_bulk() accepts resurrect_ttl for each operation
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -1077,7 +1077,7 @@ key_b: 3 ttl: 0\.(?:1|0)\d+
 
 
 
-=== TEST 23: get_bulk() honors l1_serializer instance attribute
+=== TEST 26: get_bulk() honors l1_serializer instance attribute
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -1116,7 +1116,7 @@ world nil 3
 
 
 
-=== TEST 24: get_bulk() accepts l1_serializer for each operation
+=== TEST 27: get_bulk() accepts l1_serializer for each operation
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -1158,7 +1158,7 @@ world nil 3
 
 
 
-=== TEST 25: get_bulk() honors shm_set_tries instance attribute
+=== TEST 28: get_bulk() honors shm_set_tries instance attribute
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -1215,7 +1215,7 @@ could not write to lua_shared_dict 'cache_shm' after 1 tries (no memory)
 
 
 
-=== TEST 26: get_bulk() accepts shm_set_tries for each operation
+=== TEST 29: get_bulk() accepts shm_set_tries for each operation
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -1272,7 +1272,7 @@ could not write to lua_shared_dict 'cache_shm' after 1 tries (no memory)
 
 
 
-=== TEST 27: get_bulk() operations wait on lock if another thread is fetching the same key
+=== TEST 30: get_bulk() operations wait on lock if another thread is fetching the same key
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -1342,7 +1342,7 @@ hello nil 2
 
 
 
-=== TEST 28: get_bulk() operations reports timeout on lock if another thread is fetching the same key
+=== TEST 31: get_bulk() operations reports timeout on lock if another thread is fetching the same key
 --- http_config eval: $::HttpConfig
 --- config
     location = /t {
@@ -1414,7 +1414,7 @@ nil could not acquire callback lock: timeout nil
 
 
 
-=== TEST 29: get_bulk() opts.concurrency: default is 3 (with 3 ops)
+=== TEST 32: get_bulk() opts.concurrency: default is 3 (with 3 ops)
 --- http_config eval: $::HttpConfig
 --- log_level: debug
 --- config
@@ -1450,7 +1450,7 @@ main thread running callbacks 3 to 3
 
 
 
-=== TEST 30: get_bulk() opts.concurrency: default is 3 (with 6 ops)
+=== TEST 33: get_bulk() opts.concurrency: default is 3 (with 6 ops)
 --- http_config eval: $::HttpConfig
 --- log_level: debug
 --- config
@@ -1489,7 +1489,7 @@ main thread running callbacks 5 to 6
 
 
 
-=== TEST 31: get_bulk() opts.concurrency: default is 3 (with 7 ops)
+=== TEST 34: get_bulk() opts.concurrency: default is 3 (with 7 ops)
 --- http_config eval: $::HttpConfig
 --- log_level: debug
 --- config
@@ -1529,7 +1529,7 @@ main thread running callbacks 7 to 7
 
 
 
-=== TEST 32: get_bulk() opts.concurrency: default is 3 (with 1 op)
+=== TEST 35: get_bulk() opts.concurrency: default is 3 (with 1 op)
 --- http_config eval: $::HttpConfig
 --- log_level: debug
 --- config
@@ -1563,7 +1563,7 @@ main thread running callbacks 1 to 1
 
 
 
-=== TEST 33: get_bulk() opts.concurrency: 1 (with 3 ops)
+=== TEST 36: get_bulk() opts.concurrency: 1 (with 3 ops)
 --- http_config eval: $::HttpConfig
 --- log_level: debug
 --- config
@@ -1599,7 +1599,7 @@ main thread running callbacks 1 to 3
 
 
 
-=== TEST 34: get_bulk() opts.concurrency: 1 (with 6 ops)
+=== TEST 37: get_bulk() opts.concurrency: 1 (with 6 ops)
 --- http_config eval: $::HttpConfig
 --- log_level: debug
 --- config
@@ -1638,7 +1638,7 @@ main thread running callbacks 1 to 6
 
 
 
-=== TEST 35: get_bulk() opts.concurrency: 6 (with 3 ops)
+=== TEST 38: get_bulk() opts.concurrency: 6 (with 3 ops)
 --- http_config eval: $::HttpConfig
 --- log_level: debug
 --- config
@@ -1674,7 +1674,7 @@ main thread running callbacks 3 to 3
 
 
 
-=== TEST 36: get_bulk() opts.concurrency: 6 (with 6 ops)
+=== TEST 39: get_bulk() opts.concurrency: 6 (with 6 ops)
 --- http_config eval: $::HttpConfig
 --- log_level: debug
 --- config
@@ -1718,7 +1718,7 @@ main thread running callbacks 6 to 6
 
 
 
-=== TEST 37: get_bulk() opts.concurrency: 6 (with 7 ops)
+=== TEST 40: get_bulk() opts.concurrency: 6 (with 7 ops)
 --- http_config eval: $::HttpConfig
 --- log_level: debug
 --- config
@@ -1759,7 +1759,7 @@ thread 4 running callbacks 7 to 7
 
 
 
-=== TEST 38: get_bulk() opts.concurrency: 6 (with 1 op)
+=== TEST 41: get_bulk() opts.concurrency: 6 (with 1 op)
 --- http_config eval: $::HttpConfig
 --- log_level: debug
 --- config
@@ -1793,7 +1793,7 @@ main thread running callbacks 1 to 1
 
 
 
-=== TEST 39: get_bulk() opts.concurrency: 6 (with 7 ops)
+=== TEST 42: get_bulk() opts.concurrency: 6 (with 7 ops)
 --- http_config eval: $::HttpConfig
 --- log_level: debug
 --- config

--- a/t/13-get_bulk.t
+++ b/t/13-get_bulk.t
@@ -334,7 +334,7 @@ nil nil nil
 
             local res, err = cache:get_bulk({
                 "key_a", nil, function() return 1 end, nil,
-                "key_b", nil, function() return 2 end, { skip_callback = true },
+                "key_b", { skip_callback = true }, function() return 2 end, nil,
                 "key_c", nil, function() return 3 end, nil,
                 n = 3,
             })
@@ -371,9 +371,9 @@ nil nil nil
             local cache = assert(mlcache.new("my_mlcache", "cache_shm"))
 
             local res, err = cache:get_bulk({
-                "key_a", nil, function() return 1 end, { skip_callback = true },
-                "key_b", nil, function() return 2 end, { skip_callback = true },
-                "key_c", nil, function() return 3 end, { skip_callback = true },
+                "key_a", { skip_callback = true }, function() return 1 end, nil,
+                "key_b", { skip_callback = true }, function() return 2 end, nil,
+                "key_c", { skip_callback = true }, function() return 3 end, nil,
                 n = 3,
             }, { skip_callback = false })
 
@@ -393,7 +393,7 @@ nil nil nil
 GET /t
 --- response_body
 1 nil 3
-1 nil 3
+2 nil 3
 3 nil 3
 --- no_error_log
 [error]


### PR DESCRIPTION
While ipc.lua wraps the sleep in a pcall since sleep is not available in all ngx_lua contexts, the library resty.lock doesn't show the same consideration.
```
failed to run log_by_lua*: /usr/local/api-gateway/lualib/resty/lock.lua:153: API disabled in the context of log_by_lua*
stack traceback:
    [C]: in function 'sleep'
    /usr/local/api-gateway/lualib/resty/lock.lua:153: in function 'lock'
    /usr/local/share/lua/5.1/resty/mlcache.lua:685: in function 'get'
```

My proposal is to make callback phase optional by adding a flag skip_callback.
By default, the flag is false but can be specified in :
- new() function
- get() - overrides the default and the value set in new()
- get_bulk() - if set at bulk level then it overrides skip_callback from entry level or new() function;